### PR TITLE
Only save user-assigned order addresses if they are not new records.

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -50,6 +50,12 @@ Spree::Address.class_eval do
     a
   end
 
+  # Copied from Spree, modified to ignore user_id when checking for a blank
+  # address.
+  def empty?
+    attributes.except('id', 'created_at', 'updated_at', 'order_id', 'country_id', 'user_id').all? { |_, v| v.nil? }
+  end
+
   # can modify an address if it's not been used in an completed order
   # Users of the gem can override this method to provide different rules.
   # See also Spree::Order#can_update_addresses? and Spree::User#can_update_addresses?

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -5,7 +5,7 @@ Spree::Order.class_eval do
 
   state_machine.after_transition to: :complete, do: :delink_addresses
   before_validation :delink_addresses_validation, if: :complete?
-  # before_validation :merge_user_addresses, unless: :complete?
+  before_validation :merge_user_addresses, unless: :complete?
 
   after_save :touch_addresses
 
@@ -191,7 +191,7 @@ Spree::Order.class_eval do
 
         if self.bill_address.user_id.nil?
           self.bill_address.user = self.user
-          self.bill_address.save
+          self.bill_address.save unless self.bill_address.new_record? || !self.bill_address.valid?
         end
       end
 
@@ -210,7 +210,7 @@ Spree::Order.class_eval do
 
           if self.ship_address.user_id.nil?
             self.ship_address.user = self.user
-            self.ship_address.save
+            self.ship_address.save unless self.ship_address.new_record? || !self.ship_address.valid?
           end
         end
       end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -194,7 +194,7 @@ Spree::Order.class_eval do
     if user
       l = Spree::AddressBookList.new(user)
 
-      if self.bill_address
+      if self.bill_address && self.bill_address.valid?
         bill = l.find(self.bill_address)
         if bill
           if self.bill_address_id != bill.id
@@ -210,7 +210,7 @@ Spree::Order.class_eval do
         end
       end
 
-      if self.ship_address
+      if self.ship_address && self.ship_address.valid?
         if self.ship_address.same_as?(self.bill_address)
           self.ship_address = self.bill_address
         else

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -150,10 +150,10 @@ Spree::Order.class_eval do
   def discard_blank_addresses
     return unless self.state == 'address' || self.state == 'cart'
 
-    if bill_address && bill_address.invalid? && bill_address.address1.blank?
+    if bill_address && bill_address.invalid? && bill_address.blank?
       self.bill_address = nil
     end
-    if ship_address && ship_address.invalid? && ship_address.address1.blank?
+    if ship_address && ship_address.invalid? && ship_address.blank?
       self.ship_address = nil
     end
   end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -44,7 +44,7 @@ Spree.user_class.class_eval do
           self.bill_address = self.bill_address.clone
         end
         self.bill_address.user = self
-        self.bill_address.save unless self.bill_address.new_record?
+        self.bill_address.save unless self.bill_address.new_record? || !self.bill_address.valid?
       end
     end
 
@@ -62,7 +62,7 @@ Spree.user_class.class_eval do
           self.ship_address = self.ship_address.clone
         end
         self.ship_address.user = self
-        self.ship_address.save unless self.ship_address.new_record?
+        self.ship_address.save unless self.ship_address.new_record? || !self.ship_address.valid?
       end
     end
   end

--- a/spec/features/checkout_address_selection_spec.rb
+++ b/spec/features/checkout_address_selection_spec.rb
@@ -197,16 +197,15 @@ feature "Address selection during checkout" do
       end
 
       scenario 'a user can still check out' do
+        user.addresses.where.not(address1: nil).delete_all
         restart_checkout
         expect(current_path).to eq('/checkout/address')
 
         within '#billing' do
-          choose I18n.t(:other_address, scope: :address_book)
           fill_in_address(address1)
         end
 
         within '#shipping' do
-          choose I18n.t(:other_address, scope: :address_book)
           fill_in_address(address2)
         end
 

--- a/spec/features/checkout_address_selection_spec.rb
+++ b/spec/features/checkout_address_selection_spec.rb
@@ -213,6 +213,7 @@ feature "Address selection during checkout" do
         end
 
         within '#shipping' do
+          uncheck 'order_use_billing'
           fill_in_address(address2)
         end
 

--- a/spec/features/checkout_address_selection_spec.rb
+++ b/spec/features/checkout_address_selection_spec.rb
@@ -179,6 +179,42 @@ feature "Address selection during checkout" do
       end.to change { user.addresses.count }.by(1)
     end
 
+    context 'with invalid null addresses in the database' do
+      let(:nil_address) {
+        a = nil
+        5.times do
+          a = Spree::Address.new(user: user)
+          a.save(validate: false)
+        end
+        a
+      }
+
+      let(:address1) { build(:fake_address) }
+      let(:address2) { build(:fake_address) }
+
+      before(:each) do
+        expect(nil_address.id).to be > 0
+      end
+
+      scenario 'a user can still check out' do
+        restart_checkout
+        expect(current_path).to eq('/checkout/address')
+
+        within '#billing' do
+          choose I18n.t(:other_address, scope: :address_book)
+          fill_in_address(address1)
+        end
+
+        within '#shipping' do
+          choose I18n.t(:other_address, scope: :address_book)
+          fill_in_address(address2)
+        end
+
+        complete_checkout
+        expect(page).to have_content("processed successfully")
+      end
+    end
+
     describe "when invalid address is entered" do
       let(:address) do
         Spree::Address.new(:firstname => nil, :state => state)
@@ -383,7 +419,7 @@ feature "Address selection during checkout" do
         end.to_not change{ user.addresses.count }
       end
 
-      it 'should assign the the user default addresses to the order' do
+      it 'should assign the user default addresses to the order' do
         user.update_attributes!(
           bill_address_id: user.addresses.first.id,
           ship_address_id: create(:address, user: user).id

--- a/spec/features/checkout_address_selection_spec.rb
+++ b/spec/features/checkout_address_selection_spec.rb
@@ -181,6 +181,12 @@ feature "Address selection during checkout" do
 
     context 'with invalid null addresses in the database' do
       let(:nil_address) {
+        a = Spree::Address.new
+        a.save(validate: false)
+        a
+      }
+
+      let(:nil_user_address) {
         a = nil
         5.times do
           a = Spree::Address.new(user: user)
@@ -198,6 +204,7 @@ feature "Address selection during checkout" do
 
       scenario 'a user can still check out' do
         user.addresses.where.not(address1: nil).delete_all
+        user.orders.last.update_columns(bill_address_id: nil_user_address.id, ship_address_id: nil_address.id)
         restart_checkout
         expect(current_path).to eq('/checkout/address')
 

--- a/spec/features/guest_checkout_spec.rb
+++ b/spec/features/guest_checkout_spec.rb
@@ -1,0 +1,39 @@
+# Tests to make sure an aborted guest checkout (which due to a bug in
+# spree_auth_devise creates invalid nil addresses in the database) doesn't
+# prevent a customer from checking out.
+require 'spec_helper'
+
+feature 'Aborted guest checkout', js: true do
+  include_context 'checkout with product'
+
+  let(:user) { create(:user) }
+
+  scenario 'does not prevent later logged-in checkout' do
+    Spree::Order.delete_all
+    Spree::Address.delete_all
+
+    add_mug_to_cart
+    restart_checkout
+    fill_in 'order_email', with: 'guest@example.com'
+    click_button 'Continue'
+    click_button 'Continue'
+    sign_in_to_cart!(user)
+    click_button 'Continue'
+
+    expect(current_path).to eq(spree.checkout_state_path(:address))
+
+    expect {
+      within '#billing' do
+        fill_in_address(build(:fake_address))
+      end
+
+      within '#shipping' do
+        fill_in_address(build(:fake_address))
+      end
+
+      complete_checkout
+    }.to change{ Spree::Address.count }.by(4)
+
+    expect(Spree::Order.last.state).to eq('complete')
+  end
+end

--- a/spec/support/checkout_with_product.rb
+++ b/spec/support/checkout_with_product.rb
@@ -45,6 +45,12 @@ shared_context "checkout with product" do
     Capybara.ignore_hidden_elements = true
   end
 
+  def add_mug_to_cart
+    visit spree.root_path
+    click_link mug.name
+    click_button "add-to-cart-button"
+  end
+
   private
   def should_have_address_fields
     expect(page).to have_field("First Name")
@@ -73,12 +79,6 @@ shared_context "checkout with product" do
 
   def expected_address_format(address)
     Nokogiri::HTML(address.to_s).text
-  end
-
-  def add_mug_to_cart
-    visit spree.root_path
-    click_link mug.name
-    click_button "add-to-cart-button"
   end
 
 end

--- a/spree_address_management.gemspec
+++ b/spree_address_management.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_address_management'
-  s.version     = '2.3.2'
+  s.version     = '2.3.3'
   s.summary     = "Allows users and admins to save and manage multiple addresses"
   s.description = "A fork of spree_address_book (https://github.com/romul/spree_address_book).  This gem allows Spree users to save multiple addresses for use during checkout, and provides robust tools for admins to assign, edit, and delete addresses."
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
Also don't try to save invalid addresses and reenable merging.
