### PR TITLE
Assign guest addresses to the user when logging in and merging orders.

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -111,9 +111,13 @@ Spree::CheckoutController.class_eval do
     end
 
     addr = Spree::Address.find(id)
+    user_id = spree_current_user.try(:id)
 
-    if addr.user_id != spree_current_user.try(:id)
-      raise "Frontend address forging: address user #{addr.user_id.inspect} != current user #{spree_current_user.try(:id).inspect}"
+    if addr.user_id != user_id
+      # Allow a merged/assigned formerly guest order to have a guest address
+      if addr.user_id || (@order.bill_address_id != id && @order.ship_address_id != id)
+        raise "Frontend address forging: address user #{addr.user_id.inspect} != current user #{spree_current_user.try(:id).inspect}"
+      end
     end
 
     addr

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -141,6 +141,15 @@ Spree::Order.class_eval do
     !complete?
   end
 
+  # Overrides Spree to assign user
+  def merge_with_user_addresses!(order, user=nil)
+    merge_without_user_addresses!(order, user)
+
+    if user || self.user
+      merge_user_addresses
+    end
+  end
+  alias_method_chain :merge!, :user_addresses
 
   private
 

--- a/lib/spree_address_management/testing_support/address_helpers.rb
+++ b/lib/spree_address_management/testing_support/address_helpers.rb
@@ -1,6 +1,31 @@
 module SpreeAddressManagement
   module TestingSupport
     module AddressHelpers
+      # Select an existing address from the list of saved addresses during
+      # checkout.  Both parameters are required.  Pass an Integer or a
+      # Spree::Address for +address+, and :bill or :ship for +type+.  Pass
+      # nil or 0 for +address+ to select "Choose other address".
+      def select_address(address, type)
+        case type
+        when :bill
+          container = '#billing'
+        when :ship
+          container = '#shipping'
+        else
+          raise "Invalid type #{type}"
+        end
+
+        address = address.id if address.is_a?(Spree::Address)
+
+        within container do
+          if address.nil? || address == 0
+            choose I18n.t(:other_address, scope: :address_book)
+          else
+            choose "order_#{type}_address_id_#{address}"
+          end
+        end
+      end
+
       # Fill in an already loaded address form with the given +values+ (either a
       # Spree::Address, or a Hash mapping field names to field values).
       #

--- a/lib/spree_address_management/testing_support/address_helpers.rb
+++ b/lib/spree_address_management/testing_support/address_helpers.rb
@@ -5,7 +5,7 @@ module SpreeAddressManagement
       # checkout.  Both parameters are required.  Pass an Integer or a
       # Spree::Address for +address+, and :bill or :ship for +type+.  Pass
       # nil or 0 for +address+ to select "Choose other address".
-      def select_address(address, type)
+      def select_checkout_address(address, type)
         case type
         when :bill
           container = '#billing'

--- a/spec/features/checkout_address_selection_spec.rb
+++ b/spec/features/checkout_address_selection_spec.rb
@@ -262,7 +262,7 @@ feature "Address selection during checkout" do
         end
 
         it 'should preserve a selected address and select other ship address if the ship address fails validation' do
-          select_address(@a, :bill)
+          select_checkout_address(@a, :bill)
 
           within '#shipping' do
             choose I18n.t(:other_address, scope: :address_book)
@@ -315,7 +315,7 @@ feature "Address selection during checkout" do
       it "should save 1 new address for user" do
         expect do
           address = user.addresses.first
-          select_address(address, :bill)
+          select_checkout_address(address, :bill)
           fill_in_address(shipping, :ship)
           complete_checkout
         end.to change{ user.addresses.count }.by(1)
@@ -323,7 +323,7 @@ feature "Address selection during checkout" do
 
       it "should assign addresses to orders" do
         address = user.addresses.first
-        select_address(address, :bill)
+        select_checkout_address(address, :bill)
         fill_in_address(shipping, :ship)
         complete_checkout
         expect(page).to have_content("processed successfully")
@@ -340,7 +340,7 @@ feature "Address selection during checkout" do
       it "should see form when new shipping address invalid" do
         address = user.addresses.first
         shipping = FactoryGirl.build(:address, :address1 => nil, :state => state)
-        select_address(address, :bill)
+        select_checkout_address(address, :bill)
         fill_in_address(shipping, :ship)
         click_button "Save and Continue"
         within("#saddress1") do
@@ -355,7 +355,7 @@ feature "Address selection during checkout" do
     describe "using saved address for billing and shipping" do
       it "should addresses to order" do
         address = user.addresses.first
-        select_address(address, :bill)
+        select_checkout_address(address, :bill)
         check "Use Billing Address"
         complete_checkout
         within("#order > div.row.steps-data > div:nth-child(1)") do
@@ -371,7 +371,7 @@ feature "Address selection during checkout" do
       it "should not add addresses to user" do
         expect do
           address = user.addresses.first
-          select_address(address, :bill)
+          select_checkout_address(address, :bill)
           check "Use Billing Address"
           complete_checkout
         end.to_not change{ user.addresses.count }
@@ -463,8 +463,8 @@ feature "Address selection during checkout" do
       it 'should not fill in the Other Address fields' do
         visit spree.checkout_state_path(:address)
 
-        select_address nil, :bill
-        select_address nil, :ship
+        select_checkout_address nil, :bill
+        select_checkout_address nil, :ship
 
         expect(find_field('order_bill_address_attributes_firstname').value).to be_blank
         expect(find_field('order_ship_address_attributes_firstname').value).to be_blank
@@ -479,7 +479,7 @@ feature "Address selection during checkout" do
       it "should save 1 new address for user" do
         expect do
           address = user.addresses.first
-          select_address(address, :ship)
+          select_checkout_address(address, :ship)
           fill_in_address(billing, :bill)
           check "Use Billing Address"
           complete_checkout
@@ -492,7 +492,7 @@ feature "Address selection during checkout" do
         scenario 'selecting addresses does not save them to the user defaults' do
           expect {
             address = user.addresses.first
-            select_address(address, :ship)
+            select_checkout_address(address, :ship)
             fill_in_address(billing, :bill)
             check "Use Billing Address"
             complete_checkout
@@ -501,7 +501,7 @@ feature "Address selection during checkout" do
       end
 
       it "should assign addresses to orders" do
-        select_address(address, :ship)
+        select_checkout_address(address, :ship)
         fill_in_address(billing, :bill)
         check "Use Billing Address"
         complete_checkout
@@ -519,7 +519,7 @@ feature "Address selection during checkout" do
       it "should see form when new billing address invalid" do
         address = user.addresses.first
         billing = FactoryGirl.build(:address, :address1 => nil, :state => state)
-        select_address(address, :ship)
+        select_checkout_address(address, :ship)
         fill_in_address(billing, :bill)
 
         click_button "Save and Continue"
@@ -536,7 +536,7 @@ feature "Address selection during checkout" do
       it "should not save address for user" do
         expect{
           address = user.addresses.first
-          select_address(address, :ship)
+          select_checkout_address(address, :ship)
           fill_in_address(address, :bill)
           check "Use Billing Address"
           complete_checkout

--- a/spec/features/checkout_address_selection_spec.rb
+++ b/spec/features/checkout_address_selection_spec.rb
@@ -262,7 +262,7 @@ feature "Address selection during checkout" do
         end
 
         it 'should preserve a selected address and select other ship address if the ship address fails validation' do
-          choose "order_bill_address_id_#{@a.id}"
+          select_address(@a, :bill)
 
           within '#shipping' do
             choose I18n.t(:other_address, scope: :address_book)
@@ -315,7 +315,7 @@ feature "Address selection during checkout" do
       it "should save 1 new address for user" do
         expect do
           address = user.addresses.first
-          choose "order_bill_address_id_#{address.id}"
+          select_address(address, :bill)
           fill_in_address(shipping, :ship)
           complete_checkout
         end.to change{ user.addresses.count }.by(1)
@@ -323,7 +323,7 @@ feature "Address selection during checkout" do
 
       it "should assign addresses to orders" do
         address = user.addresses.first
-        choose "order_bill_address_id_#{address.id}"
+        select_address(address, :bill)
         fill_in_address(shipping, :ship)
         complete_checkout
         expect(page).to have_content("processed successfully")
@@ -340,7 +340,7 @@ feature "Address selection during checkout" do
       it "should see form when new shipping address invalid" do
         address = user.addresses.first
         shipping = FactoryGirl.build(:address, :address1 => nil, :state => state)
-        choose "order_bill_address_id_#{address.id}"
+        select_address(address, :bill)
         fill_in_address(shipping, :ship)
         click_button "Save and Continue"
         within("#saddress1") do
@@ -355,7 +355,7 @@ feature "Address selection during checkout" do
     describe "using saved address for billing and shipping" do
       it "should addresses to order" do
         address = user.addresses.first
-        choose "order_bill_address_id_#{address.id}"
+        select_address(address, :bill)
         check "Use Billing Address"
         complete_checkout
         within("#order > div.row.steps-data > div:nth-child(1)") do
@@ -371,7 +371,7 @@ feature "Address selection during checkout" do
       it "should not add addresses to user" do
         expect do
           address = user.addresses.first
-          choose "order_bill_address_id_#{address.id}"
+          select_address(address, :bill)
           check "Use Billing Address"
           complete_checkout
         end.to_not change{ user.addresses.count }
@@ -463,13 +463,8 @@ feature "Address selection during checkout" do
       it 'should not fill in the Other Address fields' do
         visit spree.checkout_state_path(:address)
 
-        within '#billing' do
-          choose I18n.t(:other_address, scope: :address_book)
-        end
-
-        within '#shipping' do
-          choose I18n.t(:other_address, scope: :address_book)
-        end
+        select_address nil, :bill
+        select_address nil, :ship
 
         expect(find_field('order_bill_address_attributes_firstname').value).to be_blank
         expect(find_field('order_ship_address_attributes_firstname').value).to be_blank
@@ -484,7 +479,7 @@ feature "Address selection during checkout" do
       it "should save 1 new address for user" do
         expect do
           address = user.addresses.first
-          choose "order_ship_address_id_#{address.id}"
+          select_address(address, :ship)
           fill_in_address(billing, :bill)
           check "Use Billing Address"
           complete_checkout
@@ -497,7 +492,7 @@ feature "Address selection during checkout" do
         scenario 'selecting addresses does not save them to the user defaults' do
           expect {
             address = user.addresses.first
-            choose "order_ship_address_id_#{address.id}"
+            select_address(address, :ship)
             fill_in_address(billing, :bill)
             check "Use Billing Address"
             complete_checkout
@@ -506,7 +501,7 @@ feature "Address selection during checkout" do
       end
 
       it "should assign addresses to orders" do
-        choose "order_ship_address_id_#{address.id}"
+        select_address(address, :ship)
         fill_in_address(billing, :bill)
         check "Use Billing Address"
         complete_checkout
@@ -524,7 +519,7 @@ feature "Address selection during checkout" do
       it "should see form when new billing address invalid" do
         address = user.addresses.first
         billing = FactoryGirl.build(:address, :address1 => nil, :state => state)
-        choose "order_ship_address_id_#{address.id}"
+        select_address(address, :ship)
         fill_in_address(billing, :bill)
 
         click_button "Save and Continue"
@@ -541,7 +536,7 @@ feature "Address selection during checkout" do
       it "should not save address for user" do
         expect{
           address = user.addresses.first
-          choose "order_ship_address_id_#{address.id}"
+          select_address(address, :ship)
           fill_in_address(address, :bill)
           check "Use Billing Address"
           complete_checkout

--- a/spec/features/guest_checkout_edit_address_spec.rb
+++ b/spec/features/guest_checkout_edit_address_spec.rb
@@ -1,6 +1,4 @@
-# Tests to make sure an aborted guest checkout (which due to a bug in
-# spree_auth_devise creates invalid nil addresses in the database) doesn't
-# prevent a customer from checking out.
+# Tests to ensure a guest can edit addresses using the Edit link on checkout.
 require 'spec_helper'
 
 feature 'Guest order address editing', js: true do
@@ -58,4 +56,3 @@ feature 'Guest order address editing', js: true do
     expect(Spree::Order.last.state).to eq('complete')
   end
 end
-

--- a/spec/features/guest_checkout_spec.rb
+++ b/spec/features/guest_checkout_spec.rb
@@ -8,32 +8,62 @@ feature 'Aborted guest checkout', js: true do
 
   let(:user) { create(:user) }
 
-  scenario 'does not prevent later logged-in checkout' do
+  before(:each) do
     Spree::Order.delete_all
     Spree::Address.delete_all
 
     add_mug_to_cart
     restart_checkout
     fill_in 'order_email', with: 'guest@example.com'
-    click_button 'Continue'
-    click_button 'Continue'
+    click_button 'Continue' # On registration page
+    expect(current_path).to match(/(checkout|address)$/)
+  end
+
+  scenario 'does not prevent later logged-in checkout when entering new addresses' do
+    click_button 'Continue' # On address page (expecting failure)
+
     sign_in_to_cart!(user)
-    click_button 'Continue'
+    click_button 'Continue' # On cart page
 
     expect(current_path).to eq(spree.checkout_state_path(:address))
 
     expect {
-      within '#billing' do
-        fill_in_address(build(:fake_address))
-      end
-
-      within '#shipping' do
-        fill_in_address(build(:fake_address))
-      end
+      fill_in_address(build(:fake_address), :bill)
+      fill_in_address(build(:fake_address), :ship)
 
       complete_checkout
     }.to change{ Spree::Address.count }.by(4)
 
     expect(Spree::Order.last.state).to eq('complete')
+  end
+
+  scenario 'does not prevent logged-in checkout when reusing merged guest addresses' do
+    fill_in_address(build(:fake_address), :bill)
+    fill_in_address(build(:fake_address), :ship)
+    click_button 'Continue' # On address page
+    expect(current_path).to eq(spree.checkout_state_path(:delivery))
+
+    guest_order = Spree::Order.last
+    expect(guest_order.bill_address_id).not_to be_nil
+    expect(guest_order.ship_address_id).not_to be_nil
+
+    order = create(:order_with_line_items, user: user)
+    old_bill = order.bill_address_id
+    old_ship = order.ship_address_id
+
+    sign_in_to_cart!(user)
+    click_button 'Continue' # On cart page
+
+    expect {
+      select_address guest_order.bill_address_id, :bill
+      select_address guest_order.ship_address_id, :ship
+      click_button 'Continue' # On address page
+      expect(current_path).to eq(spree.checkout_state_path(:delivery))
+    }.not_to change{ Spree::Address.count }
+
+    expect{ complete_checkout }.to change{ Spree::Address.count }.by(2)
+
+    expect{ order.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect(guest_order.reload.state).to eq('complete')
   end
 end

--- a/spec/features/guest_checkout_spec.rb
+++ b/spec/features/guest_checkout_spec.rb
@@ -23,8 +23,6 @@ feature 'Aborted guest checkout', js: true do
     click_button 'Continue' # On address page (expecting failure)
 
     sign_in_to_cart!(user)
-    click_button 'Continue' # On cart page
-
     expect(current_path).to eq(spree.checkout_state_path(:address))
 
     expect {
@@ -53,6 +51,7 @@ feature 'Aborted guest checkout', js: true do
 
     expect {
       sign_in_to_cart!(user)
+      expect(current_path).to eq(spree.checkout_state_path(:address))
     }.to change{ Spree::Order.count }.by(-1)
 
     expect{ order.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/features/guest_checkout_spec.rb
+++ b/spec/features/guest_checkout_spec.rb
@@ -55,8 +55,8 @@ feature 'Aborted guest checkout', js: true do
     click_button 'Continue' # On cart page
 
     expect {
-      select_address guest_order.bill_address_id, :bill
-      select_address guest_order.ship_address_id, :ship
+      select_checkout_address guest_order.bill_address_id, :bill
+      select_checkout_address guest_order.ship_address_id, :ship
       click_button 'Continue' # On address page
       expect(current_path).to eq(spree.checkout_state_path(:delivery))
     }.not_to change{ Spree::Address.count }

--- a/spec/features/guest_checkout_spec.rb
+++ b/spec/features/guest_checkout_spec.rb
@@ -11,16 +11,10 @@ feature 'Aborted guest checkout', js: true do
   before(:each) do
     Spree::Order.delete_all
     Spree::Address.delete_all
-
-    add_mug_to_cart
-    restart_checkout
-    fill_in 'order_email', with: 'guest@example.com'
-    click_button 'Continue' # On registration page
-    expect(current_path).to match(/(checkout|address)$/)
   end
 
   scenario 'does not prevent later logged-in checkout when entering new addresses' do
-    click_button 'Continue' # On address page (expecting failure)
+    start_guest_checkout
 
     sign_in_to_cart!(user)
     expect(current_path).to eq(spree.checkout_state_path(:address))
@@ -36,28 +30,37 @@ feature 'Aborted guest checkout', js: true do
   end
 
   scenario 'does not prevent logged-in checkout when reusing merged guest addresses' do
+    order = create(:order_with_line_items, user: user)
+
+    start_guest_checkout
+
     fill_in_address(build(:fake_address), :bill)
     fill_in_address(build(:fake_address), :ship)
     click_button 'Continue' # On address page
     expect(current_path).to eq(spree.checkout_state_path(:delivery))
 
     guest_order = Spree::Order.last
+    expect(guest_order.id).not_to eq(order.id)
+    expect(guest_order.user_id).to be_nil
     expect(guest_order.bill_address_id).not_to be_nil
     expect(guest_order.ship_address_id).not_to be_nil
 
-    order = create(:order_with_line_items, user: user)
-    old_bill = order.bill_address_id
-    old_ship = order.ship_address_id
+    expect{ order.reload }.not_to raise_error
 
     expect {
       sign_in_to_cart!(user)
       expect(current_path).to eq(spree.checkout_state_path(:address))
+
+      # Force order merging to work around a change in Spree behavior
+      guest_order.merge!(order) if (order.reload rescue nil)
     }.to change{ Spree::Order.count }.by(-1)
 
     expect{ order.reload }.to raise_error(ActiveRecord::RecordNotFound)
 
     expect {
-      visit spree.checkout_state_path(:address)
+      restart_checkout
+      expect(current_path).to eq(spree.checkout_state_path(:address))
+
       select_checkout_address guest_order.bill_address_id, :bill
       select_checkout_address guest_order.ship_address_id, :ship
       click_button 'Continue' # On address page

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -89,6 +89,18 @@ describe Spree::Order do
       end
     end
 
+    it 'merges user addresses from a merged guest order' do
+      guest_order = create(:shipped_order, user: nil, email: 'guest@example.com')
+
+      expect(guest_order.bill_address.user_id).to be_nil
+      expect(guest_order.ship_address.user_id).to be_nil
+
+      guest_order.merge!(order, user)
+
+      expect(guest_order.bill_address.user_id).to eq(user.id)
+      expect(guest_order.ship_address.user_id).to eq(user.id)
+    end
+
     it 'should clone addresses on complete' do
       expect( order.state ).to eq 'cart'
       until order.complete?

--- a/spec/support/checkout_with_product.rb
+++ b/spec/support/checkout_with_product.rb
@@ -51,6 +51,15 @@ shared_context "checkout with product" do
     click_button "add-to-cart-button"
   end
 
+  # Adds a mug to the cart and proceeds to the address step as a guest
+  def start_guest_checkout
+    add_mug_to_cart
+    restart_checkout
+    fill_in 'order_email', with: 'guest@example.com'
+    click_button 'Continue' # On registration page
+    expect(current_path).to match(/(checkout|address)$/)
+  end
+
   private
   def should_have_address_fields
     expect(page).to have_field("First Name")

--- a/spree_address_management.gemspec
+++ b/spree_address_management.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_address_management'
-  s.version     = '2.3.6'
+  s.version     = '2.3.7'
   s.summary     = "Allows users and admins to save and manage multiple addresses"
   s.description = "A fork of spree_address_book (https://github.com/romul/spree_address_book).  This gem allows Spree users to save multiple addresses for use during checkout, and provides robust tools for admins to assign, edit, and delete addresses."
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
This fixes a "Frontend address forging" error when a user proceeds part way through checkout while logged in, then part way while logged out, then logs in and the orders are merged.
